### PR TITLE
Fix target framework for Sylvan.Data

### DIFF
--- a/source/Sylvan.Data.Tests/ExtendedDataReaderTests.cs
+++ b/source/Sylvan.Data.Tests/ExtendedDataReaderTests.cs
@@ -20,7 +20,7 @@ namespace Sylvan.Data
 				new CustomDataColumn<int>("RowNum", r => csvReader.RowNumber)
 			);
 			var sw = new StringWriter();
-			var wo = new CsvDataWriterOptions { NewLine = "\n" };
+			var wo = new CsvDataWriterOptions { NewLine = "\n", DateTimeFormat = "yyyy-MM-dd" };
 			var csvWriter = CsvDataWriter.Create(sw, wo);
 			csvWriter.Write(data);
 			Assert.Equal("Name,Number,Date,ImportDate,RowNum\na,1010,2022-01-01,2022-01-03,1\nb,1020,2022-01-02,2022-01-03,2\n", sw.ToString());			

--- a/source/Sylvan.Data/Sylvan.Data.csproj
+++ b/source/Sylvan.Data/Sylvan.Data.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.1</TargetFrameworks>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <VersionPrefix>0.1.2</VersionPrefix>
     <Description>A .NET library of types for working with data objects.</Description>
     <PackageTags>data;datareader;ADO.NET</PackageTags>    
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Sylvan.Data now targets netstandard 2.0, which covers the previous targets of net4.8 and ns2.1.

Fixes a unit test.