### PR TITLE
Set ContinuousIntegrationBuild for Release configuration only

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,10 +15,9 @@
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <PackageProjectUrl>https://github.com/MarkPflug/Sylvan</PackageProjectUrl>
 
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild Condition="$(Configuration) == 'Release'">true</ContinuousIntegrationBuild>
     <EmbedAllSources>true</EmbedAllSources>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DeterministicSourcePaths>true</DeterministicSourcePaths>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
Setting `ContinuousIntegrationBuild` to `true` breaks debugging in JetBrains Rider.

Also, `DeterministicSourcePaths` is automatically set to `true` when [`ContinuousIntegrationBuild` is `true`][1] (since [`Deterministic ` defaults to `true`][2]).

[1]: https://github.com/dotnet/roslyn/blob/Visual-Studio-2022-Version-17.3.1/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets#L207
[2]: https://github.com/dotnet/sdk/blob/v6.0.402/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.props#L34