### PR TITLE
Do not directly await a Task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,8 @@ dotnet_style_require_accessibility_modifiers = never
 # CA1028: If possible, make the underlying type of PrimitiveType System.Int32 instead of byte.
 dotnet_diagnostic.CA1028.severity = none
 
+# CA2007: Do not directly await a Task
+dotnet_diagnostic.CA2007.severity = warning
 
 # xUnit2013: Do not use equality check to check for collection size.
 dotnet_diagnostic.xUnit2013.severity = suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
   </ItemGroup>
 
 	<PropertyGroup Condition="$(IsTestProject) == true">
-		<NoWarn>xunit2013</NoWarn>
+		<NoWarn>xunit2013;CA2007</NoWarn>
 	</PropertyGroup>
     
 

--- a/source/Sylvan.Benchmarks/Sylvan.Benchmarks.csproj
+++ b/source/Sylvan.Benchmarks/Sylvan.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
    <TargetFrameworks>net6.0</TargetFrameworks>
     <OutputType>exe</OutputType>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
@@ -257,7 +257,7 @@ partial class CsvDataReader
 		this.rowNumber++;
 		if (this.state == State.Open)
 		{
-			var success = await this.NextRecordAsync(cancellationToken);
+			var success = await this.NextRecordAsync(cancellationToken).ConfigureAwait(false);
 			if (this.resultSetMode == ResultSetMode.MultiResult && this.curFieldCount != this.fieldCount)
 			{
 				this.curFieldCount = 0;
@@ -288,8 +288,8 @@ partial class CsvDataReader
 	/// <inheritdoc/>
 	public override async Task<bool> NextResultAsync(CancellationToken cancellationToken)
 	{
-		while (await ReadAsync(cancellationToken)) ;
-		return await InitializeAsync();
+		while (await ReadAsync(cancellationToken).ConfigureAwait(false)) ;
+		return await InitializeAsync().ConfigureAwait(false);
 	}
 
 #if NETSTANDARD2_1

--- a/source/Sylvan.Data/DataExtensions.cs
+++ b/source/Sylvan.Data/DataExtensions.cs
@@ -73,7 +73,7 @@ public static partial class DataExtensions
 		where T : class, new()
 	{
 		var binder = DataBinder.Create<T>(reader);
-		while (await reader.ReadAsync())
+		while (await reader.ReadAsync().ConfigureAwait(false))
 		{
 			var item = new T();
 			binder.Bind(reader, item);

--- a/source/Sylvan.Data/JsonDataWriter.cs
+++ b/source/Sylvan.Data/JsonDataWriter.cs
@@ -46,15 +46,15 @@ static partial class DataExtensions {
 
 		var names = GetNames(data);
 
-		while (await data.ReadAsync())
+		while (await data.ReadAsync().ConfigureAwait(false))
 		{
 			count++;
 			WriteRecord(data, names, writer);
-			await writer.FlushAsync();
+			await writer.FlushAsync().ConfigureAwait(false);
 		}
 
 		writer.WriteEndArray();
-		await writer.FlushAsync();
+		await writer.FlushAsync().ConfigureAwait(false);
 		return count;
 	}
 

--- a/source/Sylvan.Data/SchemaAnalyzer.cs
+++ b/source/Sylvan.Data/SchemaAnalyzer.cs
@@ -149,7 +149,7 @@ public sealed partial class SchemaAnalyzer
 
 		var sw = Stopwatch.StartNew();
 		int c = 0;
-		while (await dataReader.ReadAsync() && c++ < rowCount)
+		while (await dataReader.ReadAsync().ConfigureAwait(false) && c++ < rowCount)
 		{
 			for (int i = 0; i < dataReader.FieldCount; i++)
 			{

--- a/source/Sylvan.Data/TransformDataReader.cs
+++ b/source/Sylvan.Data/TransformDataReader.cs
@@ -273,7 +273,7 @@ sealed class TransformDataReader : DbDataReader, IDbColumnSchemaGenerator
 
 	public override async Task<bool> ReadAsync(CancellationToken cancel)
 	{
-		while (await this.reader.ReadAsync(cancel))
+		while (await this.reader.ReadAsync(cancel).ConfigureAwait(false))
 		{
 			underlyingRow++;
 			if (this.predicate(this))


### PR DESCRIPTION
I.e., always call `ConfigureAwait(false)` on tasks (except in tests and benchmarks projects).

Also increase CA2007 severity to warning in order to catch them all.