### PR TITLE
Call async methods when in an async method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,8 @@ dotnet_style_require_accessibility_modifiers = never
 # CA1028: If possible, make the underlying type of PrimitiveType System.Int32 instead of byte.
 dotnet_diagnostic.CA1028.severity = none
 
+# CA1849: Call async methods when in an async method
+dotnet_diagnostic.CA1849.severity = warning
 
 # xUnit2013: Do not use equality check to check for collection size.
 dotnet_diagnostic.xUnit2013.severity = suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
   </ItemGroup>
 
 	<PropertyGroup Condition="$(IsTestProject) == true">
-		<NoWarn>xunit2013</NoWarn>
+		<NoWarn>xunit2013;CA1849</NoWarn>
 	</PropertyGroup>
     
 

--- a/source/Sylvan.Benchmarks/Sylvan.Benchmarks.csproj
+++ b/source/Sylvan.Benchmarks/Sylvan.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
    <TargetFrameworks>net6.0</TargetFrameworks>
     <OutputType>exe</OutputType>
+    <NoWarn>$(NoWarn);CA1849</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Sylvan.Data.Csv/CsvDataWriter+Async.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter+Async.cs
@@ -88,7 +88,7 @@ partial class CsvDataWriter
 				}
 
 				var field = i < fieldCount ? fieldInfos[i] : FieldInfo.Generic;
-				if (field.allowNull && reader.IsDBNull(i))
+				if (field.allowNull && await reader.IsDBNullAsync(i, cancel).ConfigureAwait(false))
 				{
 					continue;
 				}


### PR DESCRIPTION
Except in tests and benchmarks projects.

Also increase CA1849 severity to warning in order to catch them all.