### PR TITLE
Fix writing DateTimeOffset objects

### DIFF
--- a/source/Sylvan.Data.Csv/CsvDataWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter.cs
@@ -133,6 +133,27 @@ public sealed partial class CsvDataWriter
 #endif
 		}
 
+		if (type == typeof(DateTimeOffset))
+		{
+			var fmt = this.dateTimeOffsetFormat;
+#if SPAN
+			if (IsFastDateTimeOffset)
+			{
+				return fmt == null
+					? DateTimeOffsetIsoFastFieldWriter.Instance
+					: DateTimeOffsetFormatFastFieldWriter.Instance;
+			}
+			else
+			{
+				return fmt == null
+					? DateTimeOffsetIsoFieldWriter.Instance
+					: DateTimeOffsetFormatFieldWriter.Instance;
+			}
+#else
+			return DateTimeOffsetFormatFieldWriter.Instance;
+#endif
+		}
+
 		if (type == typeof(Guid))
 		{
 #if SPAN
@@ -322,6 +343,15 @@ public sealed partial class CsvDataWriter
 		}
 	}
 
+	bool IsFastDateTimeOffset
+	{
+		get
+		{
+			return IsInvariantCulture && IsFastConfig
+				&& this.dateTimeOffsetFormat == CsvDataWriterOptions.Default.DateTimeOffsetFormat;
+		}
+	}
+
 	bool IsFastTimeSpan
 	{
 		get
@@ -338,7 +368,7 @@ public sealed partial class CsvDataWriter
 		get
 		{
 			return IsInvariantCulture && IsFastConfig
-				&& this.dateOnlyFormat == CsvDataWriterOptions.Default.DateTimeFormat;
+				&& this.dateOnlyFormat == CsvDataWriterOptions.Default.DateOnlyFormat;
 		}
 	}
 

--- a/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
@@ -67,7 +67,7 @@ public sealed class CsvDataWriterOptions
 	public string? DateTimeFormat { get; set; }
 
 	/// <summary>
-	/// The format string used when writing DateTime values. The default is \"O\".
+	/// The format string used when writing DateTimeOffset values. The default is \"O\".
 	/// </summary>
 	public string? DateTimeOffsetFormat { get; set; }
 


### PR DESCRIPTION
This was caught when running the `WriteDateTimeOffset` test on a machine configured with the `fr-CH` culture which was failing with the following error:
> Assert.Equal() Failure
Expected: 2021-02-06T00:00:00.0000000+01:00
Actual:   2021-06-02T00:00:00.0000000+01:00
   at Sylvan.Data.Csv.CsvDataWriterTests.WriteDateTimeOffset() in Sylvan/source/Sylvan.Data.Csv.Tests/CsvDataWriterTests.cs:line 232