### PR TITLE
Fast writer paths for Int16 and Byte

### DIFF
--- a/source/Sylvan.Data.Csv/CsvDataWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter.cs
@@ -93,6 +93,28 @@ public sealed partial class CsvDataWriter
 		{
 			return StringFieldWriter.Instance;
 		}
+		if (type == typeof(byte))
+		{
+#if SPAN
+			return IsFastNumeric
+				? ByteFastFieldWriter.Instance
+				: ByteFieldWriter.Instance;
+#else
+			return ByteFieldWriter.Instance;
+#endif
+		}
+
+		if (type == typeof(short))
+		{
+#if SPAN
+			return IsFastNumeric
+				? Int16FastFieldWriter.Instance
+				: Int16FieldWriter.Instance;
+#else
+			return Int16FieldWriter.Instance;
+#endif
+		}
+
 		if (type == typeof(int))
 		{
 #if SPAN


### PR DESCRIPTION
`CsvDataWriter.GetWriter` falls back to a boxing `DataReader.GetValue()` call for `Byte`/`byte` (`TINYINT`) and `Int16`/`short` (`SMALLINT`) types. This is not functionally wrong and these types aren't terribly common, but it's still needlessly wasteful to go through boxing for them when the input does contain them. With this all scalar types are covered except `char` (which remains the odd one out, as most providers don't use it at all in favor of `string`; with possible encoding issues, supporting that specially may be more complicated than is warranted).

This PR adds fast writer support (for both the typed and untyped cases) and fixes two other problems with the generic object path:
* A copy-paste error had the value for `long` cast to `int`. As unboxing doesn't perform type conversions, this cast should fail at runtime.
* There was no type check for `decimal` even though we have a writer for it, so this fell back to generic string formatting.

I didn't add tests for these since I'm not familiar enough with the code base to know what should be tested and where the tests should go, but obviously I recommend writing these before adding this code (especially for the `long` case, which is a bug rather than a perf improvement).