### PR TITLE
Added option to suppress CsvFormatExceptions

### DIFF
--- a/source/Sylvan.Data.Csv/CsvDataReaderOptions.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReaderOptions.cs
@@ -97,6 +97,24 @@ public enum ResultSetMode
 }
 
 /// <summary>
+/// Specifies how the the reader reacts when a unescaped is encountered, that is not the terminating quote of the field.
+/// </summary>
+public enum UnescapedQuoteHandling
+{
+	/// <summary>
+	/// Throws a FormatException when invalid data is encountered.
+	/// </summary>
+	Throw = 1,
+
+	/// <summary>
+	/// Searches for the next terminating quote and continues reading.
+	/// If no terminating quote is found, an exception is throw anyway.
+	/// NOTE: This can lead to invalid data.
+	/// </summary>
+	AllowIfTerminatingQuoteIsFound = 2,
+}
+
+/// <summary>
 /// Options for configuring a CsvDataReader.
 /// </summary>
 public sealed class CsvDataReaderOptions
@@ -128,7 +146,14 @@ public sealed class CsvDataReaderOptions
 
 		this.BinaryEncoding = BinaryEncoding.Base64;
 		this.ResultSetMode = ResultSetMode.SingleResult;
+		this.FormatExceptionHandling = UnescapedQuoteHandling.Throw;
 	}
+
+	/// <summary>
+	/// Specifies the behavior of the reader when encountering invalid formatted data.
+	/// The default is <see cref="UnescapedQuoteHandling.Throw"/>.
+	/// </summary>
+	public UnescapedQuoteHandling FormatExceptionHandling { get; set; }
 
 	/// <summary>
 	/// Indicates the behavior of result transitions.

--- a/source/Sylvan.Data.Csv/Sylvan.Data.Csv.csproj
+++ b/source/Sylvan.Data.Csv/Sylvan.Data.Csv.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
-		<VersionPrefix>1.3.3</VersionPrefix>
+		<VersionPrefix>1.4.0</VersionPrefix>
 		<Description>A .NET library for reading and writing delimited CSV data.</Description>
 		<PackageTags>csv;delimited;data;datareader;datawriter;simd</PackageTags>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
This PR allows to suppress the CsvFormatExceptions when the field has a closing quote character.
This seems to be the least wrong behavior i could come up with.

I often have to work with CsvFile from external sources which i have no control over.
There it would be better to have "wrong" data than no data at all.

This PR is in response to https://github.com/MarkPflug/Sylvan/issues/206