### PR TITLE
feat: Try get ordinal for column name

### DIFF
--- a/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
+++ b/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
@@ -212,6 +212,7 @@ public class CsvDataReaderTests
 			Assert.Equal(0, csv.RowNumber);
 			Assert.Equal("", csv.GetName(0));
 			Assert.Throws<IndexOutOfRangeException>(() => csv.GetOrdinal("Id"));
+			Assert.False(csv.TryGetOrdinal("Id", out _));
 			Assert.True(await csv.ReadAsync());
 			Assert.Equal(1, csv.RowNumber);
 			Assert.Equal("1", csv[0]);
@@ -249,6 +250,7 @@ public class CsvDataReaderTests
 			Assert.Equal(3, csv.GetOrdinal("D"));
 			Assert.Equal("A", csv.GetName(0));
 			Assert.Throws<IndexOutOfRangeException>(() => csv.GetOrdinal("Id"));
+			Assert.False(csv.TryGetOrdinal("Id", out _));
 			Assert.True(await csv.ReadAsync());
 			Assert.Equal(1, csv.RowNumber);
 			Assert.Equal("1", csv[0]);
@@ -372,7 +374,10 @@ public class CsvDataReaderTests
 
 		var csv = CsvDataReader.Create(new StringReader(data));
 		Assert.Equal(0, csv.GetOrdinal("a"));
+		Assert.True(csv.TryGetOrdinal("a", out int ordinal));
+		Assert.Equal(0, ordinal);
 		Assert.Throws<AmbiguousColumnException>(() => csv.GetOrdinal("b"));
+		Assert.False(csv.TryGetOrdinal("b", out _));
 		var schema = csv.GetColumnSchema();
 		Assert.Equal("a", schema[0].ColumnName);
 		Assert.Equal("b", schema[1].ColumnName);

--- a/source/Sylvan.Data.Csv/CsvDataReader.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader.cs
@@ -1443,6 +1443,28 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 		throw new IndexOutOfRangeException();
 	}
 
+	/// <summary>
+	/// Try to get the ordinal of the given column name
+	/// </summary>
+	/// <param name="name">Column name</param>
+	/// <param name="idx">Ordinal value, if the column exists</param>
+	/// <returns>True if the columns exists, else false</returns>
+	/// <remarks>The ordinal should not be used if the return value is false</remarks>
+	public bool TryGetOrdinal(string name, out int idx)
+	{
+		if (!this.headerMap.TryGetValue(name, out idx))
+		{
+			return false;
+		}
+
+		if (idx == -1)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
 	/// <inheritdoc/>
 	public override string GetString(int ordinal)
 	{


### PR DESCRIPTION
This follows the TryX pattern common in .Net so that the method doesn't throw when a column isn't found or is duplicated. This is useful when parsing CSV files in which some columns are optional, and prevents the need to use exceptions for control flow.