### PR TITLE
Update CsvDataWriterOptions.cs

### DIFF
--- a/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
@@ -142,7 +142,7 @@ public sealed class CsvDataWriterOptions
 	public char Comment { get; set; }
 
 	/// <summary>
-	/// The string to use for line breaks separating records. The default is Environment.NewLine.
+	/// The string to use for line breaks separating records. The default is "\n".
 	/// Must be one of "\r", "\n", or "\r\n".
 	/// </summary>
 	public string NewLine { get; set; }


### PR DESCRIPTION
The newline default is "\n", not Environment.NewLine() This is probably as it should be, as it would be awkward for results to change based on what system runs the software (e.g. in mixed Windows/Unix server environments), and because all software that matters, including Excel, support \n by default.