### PR TITLE
Added CsvDataWriterOptions.QuoteNonEmptyStrings

### DIFF
--- a/source/Sylvan.Data.Csv.Tests/CsvDataWriterTests.cs
+++ b/source/Sylvan.Data.Csv.Tests/CsvDataWriterTests.cs
@@ -471,12 +471,18 @@ public class CsvDataWriterTests
 	}
 
 	[Theory]
-	[InlineData(true, "Name\n\"\"\n\n")]
-	[InlineData(false, "Name\n\n\n")]
-	public void QuoteEmptyStrings(bool mode, string result)
+	[InlineData(true, true, "\"Name\"\n\"1\"\n\"\"\n\n")]
+	[InlineData(false, true, "\"Name\"\n\"1\"\n\n\n")]
+	[InlineData(true, false, "Name\n1\n\"\"\n\n")]
+	[InlineData(false, false, "Name\n1\n\n\n")]
+	public void QuoteStringsOptions(bool emptyStringsMode, bool nonEmptyStringsMode, string result)
 	{
 		var data = new[]
 			{
+				new
+				{
+					Name = "1"
+				},
 				new
 				{
 					Name = ""
@@ -487,7 +493,7 @@ public class CsvDataWriterTests
 				},
 			};
 		var reader = data.AsDataReader();
-		var opts = new CsvDataWriterOptions { QuoteEmptyStrings = mode, NewLine = "\n" };
+		var opts = new CsvDataWriterOptions { QuoteEmptyStrings = emptyStringsMode, QuoteNonEmptyStrings = nonEmptyStringsMode, NewLine = "\n" };
 		var sw = new StringWriter();
 		var writer = CsvDataWriter.Create(sw, opts);
 		writer.Write(reader);

--- a/source/Sylvan.Data.Csv.Tests/CsvDataWriterTests.cs
+++ b/source/Sylvan.Data.Csv.Tests/CsvDataWriterTests.cs
@@ -471,11 +471,11 @@ public class CsvDataWriterTests
 	}
 
 	[Theory]
-	[InlineData(true, true, "\"Name\"\n\"1\"\n\"\"\n\n")]
-	[InlineData(false, true, "\"Name\"\n\"1\"\n\n\n")]
-	[InlineData(true, false, "Name\n1\n\"\"\n\n")]
-	[InlineData(false, false, "Name\n1\n\n\n")]
-	public void QuoteStringsOptions(bool emptyStringsMode, bool nonEmptyStringsMode, string result)
+	[InlineData(CsvStringQuoting.Default, "Name\n1\n\n\n")]
+	[InlineData(CsvStringQuoting.AlwaysQuoteEmpty, "Name\n1\n\"\"\n\n")]
+	[InlineData(CsvStringQuoting.AlwaysQuoteNonEmpty, "\"Name\"\n\"1\"\n\n\n")]
+	[InlineData(CsvStringQuoting.AlwaysQuote, "\"Name\"\n\"1\"\n\"\"\n\n")]
+	public void QuoteStringsOptions(CsvStringQuoting mode, string result)
 	{
 		var data = new[]
 			{
@@ -493,7 +493,7 @@ public class CsvDataWriterTests
 				},
 			};
 		var reader = data.AsDataReader();
-		var opts = new CsvDataWriterOptions { QuoteEmptyStrings = emptyStringsMode, QuoteNonEmptyStrings = nonEmptyStringsMode, NewLine = "\n" };
+		var opts = new CsvDataWriterOptions { QuoteStrings = mode, NewLine = "\n" };
 		var sw = new StringWriter();
 		var writer = CsvDataWriter.Create(sw, opts);
 		writer.Write(reader);

--- a/source/Sylvan.Data.Csv/CsvDataWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter.cs
@@ -447,8 +447,7 @@ public sealed partial class CsvDataWriter
 	readonly CsvWriter csvWriter;
 
 	readonly bool writeHeaders;
-	readonly bool quoteEmptyStrings;
-	readonly bool quoteNonEmptyStrings;
+	readonly CsvStringQuoting quoteStrings;
 	readonly char delimiter;
 	readonly char quote;
 	readonly char escape;
@@ -531,8 +530,7 @@ public sealed partial class CsvDataWriter
 		this.dateOnlyFormat = options.DateOnlyFormat;
 #endif
 		this.writeHeaders = options.WriteHeaders;
-		this.quoteEmptyStrings = options.QuoteEmptyStrings;
-		this.quoteNonEmptyStrings = options.QuoteNonEmptyStrings;
+		this.quoteStrings = options.QuoteStrings;
 		this.delimiter = options.Delimiter;
 		this.quote = options.Quote;
 		this.escape = options.Escape;

--- a/source/Sylvan.Data.Csv/CsvDataWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter.cs
@@ -448,6 +448,7 @@ public sealed partial class CsvDataWriter
 
 	readonly bool writeHeaders;
 	readonly bool quoteEmptyStrings;
+	readonly bool quoteNonEmptyStrings;
 	readonly char delimiter;
 	readonly char quote;
 	readonly char escape;
@@ -531,6 +532,7 @@ public sealed partial class CsvDataWriter
 #endif
 		this.writeHeaders = options.WriteHeaders;
 		this.quoteEmptyStrings = options.QuoteEmptyStrings;
+		this.quoteNonEmptyStrings = options.QuoteNonEmptyStrings;
 		this.delimiter = options.Delimiter;
 		this.quote = options.Quote;
 		this.escape = options.Escape;

--- a/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
@@ -4,6 +4,33 @@ using System.Globalization;
 namespace Sylvan.Data.Csv;
 
 /// <summary>
+/// Specifies how strings are quoted
+/// </summary>
+[Flags]
+public enum CsvStringQuoting
+{
+	/// <summary>
+	/// Strings are only quoted when it is required.
+	/// </summary>
+	Default = 0,
+
+	/// <summary>
+	/// Empty strings are always quoted. This distinguishes them from null.
+	/// </summary>
+	AlwaysQuoteEmpty = 1,
+
+	/// <summary>
+	/// Non-empty strings are always quoted. This helps prevent confusion with numbers and dates.
+	/// </summary>
+	AlwaysQuoteNonEmpty = 2,
+
+	/// <summary>
+	/// All strings are always quoted.
+	/// </summary>
+	AlwaysQuote = 3,
+}
+
+/// <summary>
 /// Options for configuring a CsvWriter.
 /// </summary>
 public sealed class CsvDataWriterOptions
@@ -30,8 +57,7 @@ public sealed class CsvDataWriterOptions
 		this.BinaryEncoding = BinaryEncoding.Base64;
 		this.Style = CsvStyle.Standard;
 		this.Delimiter = DefaultDelimiter;
-		this.QuoteEmptyStrings = false;
-		this.QuoteNonEmptyStrings = false;
+		this.QuoteStrings = CsvStringQuoting.Default;
 		this.Quote = DefaultQuote;
 		this.Escape = DefaultEscape;
 		this.Comment = DefaultComment;
@@ -123,17 +149,26 @@ public sealed class CsvDataWriterOptions
 	public char Delimiter { get; set; }
 
 	/// <summary>
-	/// Empty strings will be written as empty quotes in the CSV. 
-	/// This allows distinguishing empty strings from null.
+	/// The rules to use when quoting strings, defaults to <see cref="CsvStringQuoting.Default"/>
 	/// </summary>
-	public bool QuoteEmptyStrings { get; set; }
+	public CsvStringQuoting QuoteStrings { get; set; }
 
 	/// <summary>
-	/// All non-empty strings will be quoted regardless of whether it is necessary.
-	/// This can prevent other software from incorrectly treating strings as numbers or dates.
-	/// This setting is independent of <see cref="QuoteEmptyStrings"/>.
+	/// Empty strings will be written as empty quotes in the CSV.
+	/// This allows distinguishing empty strings from null.
 	/// </summary>
-	public bool QuoteNonEmptyStrings { get; set; }
+	[Obsolete("Use QuoteStrings instead.")]
+	public bool QuoteEmptyStrings
+	{
+		get => QuoteStrings.HasFlag(CsvStringQuoting.AlwaysQuoteEmpty);
+		set
+		{
+			if (value)
+				QuoteStrings |= CsvStringQuoting.AlwaysQuoteEmpty;
+			else
+				QuoteStrings &= ~CsvStringQuoting.AlwaysQuoteEmpty;
+		}
+	}
 
 	/// <summary>
 	/// The character to use for quoting fields. The default is '"'.
@@ -193,7 +228,7 @@ public sealed class CsvDataWriterOptions
 			Quote >= 128 ||
 			Escape >= 128 ||
 			Comment >= 128 ||
-			((QuoteEmptyStrings || QuoteNonEmptyStrings) && Style == CsvStyle.Escaped)
+			(QuoteStrings != CsvStringQuoting.Default && Style == CsvStyle.Escaped)
 			;
 		if (invalid)
 			throw new CsvConfigurationException();

--- a/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriterOptions.cs
@@ -30,6 +30,8 @@ public sealed class CsvDataWriterOptions
 		this.BinaryEncoding = BinaryEncoding.Base64;
 		this.Style = CsvStyle.Standard;
 		this.Delimiter = DefaultDelimiter;
+		this.QuoteEmptyStrings = false;
+		this.QuoteNonEmptyStrings = false;
 		this.Quote = DefaultQuote;
 		this.Escape = DefaultEscape;
 		this.Comment = DefaultComment;
@@ -127,6 +129,13 @@ public sealed class CsvDataWriterOptions
 	public bool QuoteEmptyStrings { get; set; }
 
 	/// <summary>
+	/// All non-empty strings will be quoted regardless of whether it is necessary.
+	/// This can prevent other software from incorrectly treating strings as numbers or dates.
+	/// This setting is independent of <see cref="QuoteEmptyStrings"/>.
+	/// </summary>
+	public bool QuoteNonEmptyStrings { get; set; }
+
+	/// <summary>
 	/// The character to use for quoting fields. The default is '"'.
 	/// </summary>
 	public char Quote { get; set; }
@@ -184,7 +193,7 @@ public sealed class CsvDataWriterOptions
 			Quote >= 128 ||
 			Escape >= 128 ||
 			Comment >= 128 ||
-			(QuoteEmptyStrings && Style == CsvStyle.Escaped)
+			((QuoteEmptyStrings || QuoteNonEmptyStrings) && Style == CsvStyle.Escaped)
 			;
 		if (invalid)
 			throw new CsvConfigurationException();

--- a/source/Sylvan.Data.Csv/CsvWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvWriter.cs
@@ -114,7 +114,7 @@ partial class CsvDataWriter
 		{
 			var pos = offset;
 			var needsEscape = context.writer.needsEscape;
-			if (value.Length == 0 && context.writer.quoteEmptyStrings)
+			if ((value.Length == 0 && context.writer.quoteEmptyStrings) || (value.Length > 0 && context.writer.quoteNonEmptyStrings))
 			{
 				return NeedsQuoting;
 			}

--- a/source/Sylvan.Data.Csv/CsvWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvWriter.cs
@@ -114,10 +114,15 @@ partial class CsvDataWriter
 		{
 			var pos = offset;
 			var needsEscape = context.writer.needsEscape;
-			if ((value.Length == 0 && context.writer.quoteEmptyStrings) || (value.Length > 0 && context.writer.quoteNonEmptyStrings))
+			if (value.Length == 0)
 			{
-				return NeedsQuoting;
+				if (context.writer.quoteStrings.HasFlag(CsvStringQuoting.AlwaysQuoteEmpty))
+					return NeedsQuoting;
+				else
+					return 0;
 			}
+			else if (context.writer.quoteStrings.HasFlag(CsvStringQuoting.AlwaysQuoteNonEmpty))
+				return NeedsQuoting;
 
 			if (pos + value.Length >= buffer.Length)
 				return InsufficientSpace;


### PR DESCRIPTION
Added CsvDataWriterOptions.QuoteNonEmptyStrings to force quoting of non-empty strings

Where the QuoteEmptyStrings option already exists to differentiate empty strings from nulls, this PR adds an option QuoteNonEmptyStrings that will quote all non-empty strings.

This can be useful to differentiate between the number 1 and the string "1", to prevent leading zeroes being removed from "0001" or to help prevent the string "1-Jan" from being treated as a date.