### PR TITLE
Added option to save CSV file with different encoding.

### DIFF
--- a/source/Sylvan.Data.Csv/CsvDataWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter.cs
@@ -483,10 +483,12 @@ public sealed partial class CsvDataWriter
 	/// </summary>
 	/// <param name="fileName">The path of the file to write.</param>
 	/// <param name="options">The options used to configure the writer, or null to use the defaults.</param>
-	public static CsvDataWriter Create(string fileName, CsvDataWriterOptions? options = null)
+	/// <param name="encoding">the file encoding at the end</param>
+	public static CsvDataWriter Create(string fileName, CsvDataWriterOptions? options = null, Encoding? encoding = null)
 	{
 		options ??= CsvDataWriterOptions.Default;
-		var writer = new StreamWriter(fileName, false, Encoding.UTF8);
+		encoding ??= Encoding.UTF8;
+		var writer = new StreamWriter(fileName, false, encoding);
 		return new CsvDataWriter(writer, null, options);
 	}
 

--- a/source/Sylvan.Data.Csv/Sylvan.Data.Csv.csproj
+++ b/source/Sylvan.Data.Csv/Sylvan.Data.Csv.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
-		<VersionPrefix>1.3.7</VersionPrefix>
+		<VersionPrefix>1.3.7.1-Moran</VersionPrefix>
 		<Description>A .NET library for reading and writing delimited CSV data.</Description>
 		<PackageTags>csv;delimited;data;datareader;datawriter;simd</PackageTags>
 		<Nullable>enable</Nullable>
@@ -11,6 +11,7 @@
 		<DefineConstants Condition="$(TargetFramework) == 'net6.0'">SPAN;ASYNC_DISPOSE;INTRINSICS;ENUM_SPAN_PARSE;$(DefineConstants)</DefineConstants>
 		<!-- Enable unsafe blocks for use with simd -->
 		<AllowUnsafeBlocks Condition="$(TargetFramework) == 'net6.0'">true</AllowUnsafeBlocks>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Had a requirement to save as different csv encoding figured there isn't an option here so added it.
Please notice, change the version number I add my own to avoid overriding.