### PR TITLE
Fix test failing on Windows due to newline differences

### DIFF
--- a/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
+++ b/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
@@ -166,7 +166,7 @@ public class CsvDataReaderTests
 			Assert.Equal(1, csv.RowNumber);
 			Assert.Equal("1", csv[0]);
 			Assert.Equal("John", csv[1]);
-			Assert.Equal($"Very{Environment.NewLine}Low{Environment.NewLine}", csv[2]);
+			Assert.Equal($"Very\nLow\n", csv[2]);
 			Assert.Equal("2000-11-11", csv[3]);
 			Assert.True(await csv.ReadAsync());
 			Assert.Equal(2, csv.RowNumber);


### PR DESCRIPTION
CsvDataReaderTests.Quoted() expected \n (LF) in the input to become Environment.NewLine, which is CRLF on Windows, in the output, but the reader does not do any such conversion. Fix by expecting LF in the test regardless of platform.