### PR TITLE
RowNumber exception fix.

### DIFF
--- a/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
+++ b/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
@@ -2059,6 +2059,75 @@ public class CsvDataReaderTests
 		Assert.Equal(expected, value);
 	}
 
+	[Fact]
+	public void ExceptionInit()
+	{
+		// When the malformed field is on the first row of data
+		// a different code path is used, so we need to test that independently.
+		var data =
+			"""
+			a,b,c
+			4,5,"6
+			""";
+
+		using var csv = CsvDataReader.Create(new StringReader(data));
+
+		var ex = Assert.ThrowsAny<CsvFormatException>(() => csv.Read());
+		Assert.Equal(1, csv.RowNumber);
+
+		// can read the two fields before the corrupt field
+		Assert.Equal("4", csv.GetString(0));
+		Assert.Equal("5", csv.GetString(1));
+		// but can't read the corrupt one or beyond.
+		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(2));
+		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(3));
+
+#if NET6_0_OR_GREATER
+		// Can read the raw record up to the beginning of the faulty field.
+		var s = csv.GetRawRecordSpan();
+		Assert.Equal("4,5,", s);
+#endif
+
+		// shouldn't be able to resume reading after an exception
+		Assert.ThrowsAny<InvalidOperationException>(() => csv.Read());
+		Assert.Equal(1, ex.RowNumber);
+	}
+
+	[Fact]
+	public void Exception()
+	{
+		var data =
+			"""
+			a,b,c
+			1,2,3
+			4,5,"6
+			""";
+
+		using var csv = CsvDataReader.Create(new StringReader(data));
+
+		Assert.True(csv.Read());
+		Assert.Equal(1, csv.RowNumber);
+		var ex = Assert.ThrowsAny<CsvFormatException>(() => csv.Read());
+		Assert.Equal(2, ex.RowNumber);
+
+		// can read the two fields before the corrupt field
+		Assert.Equal("4", csv.GetString(0));
+		Assert.Equal("5", csv.GetString(1));
+		// but can't read the corrupt one or beyond.
+		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(2));
+		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(3));
+
+#if NET6_0_OR_GREATER
+		// Can read the raw record up to the beginning of the faulty field.
+		var s = csv.GetRawRecordSpan();
+		Assert.Equal("4,5,", s);
+#endif
+
+		// shouldn't be able to resume reading after an exception
+		Assert.ThrowsAny<InvalidOperationException>(() => csv.Read());
+		Assert.Equal(2, ex.RowNumber);
+	}
+
 #if NET6_0_OR_GREATER
 
 	[Fact]

--- a/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
+++ b/source/Sylvan.Data.Csv.Tests/CsvDataReaderTests.cs
@@ -2079,8 +2079,8 @@ public class CsvDataReaderTests
 		Assert.Equal("4", csv.GetString(0));
 		Assert.Equal("5", csv.GetString(1));
 		// but can't read the corrupt one or beyond.
-		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(2));
-		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(3));
+		Assert.ThrowsAny<CsvFormatException>(() => csv.GetString(2));
+		Assert.ThrowsAny<CsvFormatException>(() => csv.GetString(3));
 
 #if NET6_0_OR_GREATER
 		// Can read the raw record up to the beginning of the faulty field.
@@ -2114,8 +2114,8 @@ public class CsvDataReaderTests
 		Assert.Equal("4", csv.GetString(0));
 		Assert.Equal("5", csv.GetString(1));
 		// but can't read the corrupt one or beyond.
-		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(2));
-		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(3));
+		Assert.ThrowsAny<CsvFormatException>(() => csv.GetString(2));
+		Assert.ThrowsAny<CsvFormatException>(() => csv.GetString(3));
 
 #if NET6_0_OR_GREATER
 		// Can read the raw record up to the beginning of the faulty field.
@@ -2143,7 +2143,7 @@ public class CsvDataReaderTests
 
 		Assert.True(csv.Read());
 		Assert.Equal(1, csv.RowNumber);
-		var ex = Assert.ThrowsAny<CsvFormatException>(() => csv.Read());
+		var ex = Assert.ThrowsAny<CsvRecordTooLargeException>(() => csv.Read());
 		Assert.Equal(2, ex.RowNumber);
 
 		// can read the two fields before the corrupt field
@@ -2151,8 +2151,8 @@ public class CsvDataReaderTests
 		Assert.Equal("5", csv.GetString(1));
 		// but can't read the corrupt one or beyond.
 		
-		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(2));
-		Assert.ThrowsAny<InvalidOperationException>(() => csv.GetString(3));
+		Assert.ThrowsAny<CsvRecordTooLargeException>(() => csv.GetString(2));
+		Assert.ThrowsAny<CsvRecordTooLargeException>(() => csv.GetString(3));
 
 #if NET6_0_OR_GREATER
 		// Can read the raw record up to the beginning of the faulty field.

--- a/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
@@ -218,7 +218,7 @@ partial class CsvDataReader
 				{
 					if (!GrowBuffer())
 					{
-						throw new CsvRecordTooLargeException(this.RowNumber, 0, null, null);
+						ThrowRecordTooLarge();
 					}
 				}
 				await FillBufferAsync(cancel).ConfigureAwait(false);
@@ -258,9 +258,7 @@ partial class CsvDataReader
 			{
 				if (!GrowBuffer())
 				{
-					// if we consumed the entire buffer reading this record, then this is an exceptional situation
-					// we expect a record to be able to fit entirely within the buffer.
-					throw new CsvRecordTooLargeException(this.RowNumber, fieldIdx, null, null);
+					ThrowRecordTooLarge(fieldIdx);
 				}
 			}
 			await FillBufferAsync(cancel).ConfigureAwait(false);

--- a/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
@@ -304,38 +304,9 @@ partial class CsvDataReader
 		{
 			this.rowNumber++;
 			var success = await this.NextRecordAsync(cancellationToken).ConfigureAwait(false);
-			if (!success || this.resultSetMode == ResultSetMode.MultiResult && this.curFieldCount != this.fieldCount)
-			{
-				this.curFieldCount = 0;
-				this.idx = recordStart;
-				this.state = State.End;
-				this.rowNumber = -1;
-				return false;
-			}
-			return success;
+			return ReadFinish(success);
 		}
-		else if (this.state == State.Initialized)
-		{
-			ThrowPendingException();
-			this.rowNumber++;
-			// after initizialization, the first record would already be in the buffer
-			// if hasRows is true.
-			if (hasRows)
-			{
-				this.state = State.Open;
-				return true;
-			}
-			else
-			{
-				this.state = State.End;
-			}
-		}
-		else if (this.state == State.Error)
-		{
-			throw new InvalidOperationException();
-		}
-		this.rowNumber = -1;
-		return false;
+		return ReadCommon();
 	}
 
 	/// <inheritdoc/>

--- a/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
@@ -117,9 +117,9 @@ partial class CsvDataReader
 			}
 			if (result == ReadResult.False)
 			{
-				if (this.state == State.Open && pendingException != null)
+				if (this.state == State.Open)
 				{
-					throw pendingException;
+					ThrowPendingException();
 				}
 				return true;
 			}
@@ -168,11 +168,11 @@ partial class CsvDataReader
 
 	/// <inheritdoc/>
 	public override bool Read()
-	{
-		this.rowNumber++;
+	{		
 		this.colCacheIdx = 0;
 		if (this.state == State.Open)
 		{
+			this.rowNumber++;
 			var success = this.NextRecord();
 			if (!success || (this.resultSetMode == ResultSetMode.MultiResult && this.curFieldCount != this.fieldCount))
 			{
@@ -186,10 +186,8 @@ partial class CsvDataReader
 		}
 		else if (this.state == State.Initialized)
 		{
-			if (pendingException != null)
-			{
-				throw pendingException;
-			}
+			this.rowNumber++;
+			ThrowPendingException();
 			// after initizialization, the first record would already be in the buffer
 			// if hasRows is true.
 			if (hasRows)
@@ -201,6 +199,10 @@ partial class CsvDataReader
 			{
 				this.state = State.End;
 			}
+		} 
+		else if(this.state == State.Error)
+		{
+			throw new InvalidOperationException();
 		}
 		this.rowNumber = -1;
 		return false;

--- a/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
@@ -173,38 +173,9 @@ partial class CsvDataReader
 		{
 			this.rowNumber++;
 			var success = this.NextRecord();
-			if (!success || (this.resultSetMode == ResultSetMode.MultiResult && this.curFieldCount != this.fieldCount))
-			{
-				this.curFieldCount = 0;
-				this.idx = recordStart;
-				this.state = State.End;
-				this.rowNumber = -1;
-				return false;
-			}
-			return success;
+			return ReadFinish(success);
 		}
-		if (this.state == State.Initialized)
-		{
-			ThrowPendingException();
-			this.rowNumber++;
-			// after initizialization, the first record would already be in the buffer
-			// if hasRows is true.
-			if (hasRows)
-			{
-				this.state = State.Open;
-				return true;
-			}
-			else
-			{
-				this.state = State.End;
-			}
-		}
-		else if (this.state == State.Error)
-		{
-			ThrowErrorState();
-		}
-		this.rowNumber = -1;
-		return false;
+		return ReadCommon();
 	}
 
 	/// <inheritdoc/>

--- a/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
@@ -86,7 +86,7 @@ partial class CsvDataReader
 				{
 					if (!GrowBuffer())
 					{
-						throw new CsvRecordTooLargeException(this.RowNumber, 0, null, null);
+						ThrowRecordTooLarge();
 					}
 				}
 				FillBuffer();
@@ -131,8 +131,7 @@ partial class CsvDataReader
 				{
 					// if we consumed the entire buffer reading this record, then this is an exceptional situation
 					// we expect a record to be able to fit entirely within the buffer.
-					throw new CsvRecordTooLargeException(this.RowNumber, fieldIdx, null, null);
-
+					ThrowRecordTooLarge(fieldIdx);
 				}
 			}
 			else

--- a/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
@@ -183,10 +183,10 @@ partial class CsvDataReader
 			}
 			return success;
 		}
-		else if (this.state == State.Initialized)
+		if (this.state == State.Initialized)
 		{
-			this.rowNumber++;
 			ThrowPendingException();
+			this.rowNumber++;
 			// after initizialization, the first record would already be in the buffer
 			// if hasRows is true.
 			if (hasRows)
@@ -198,10 +198,10 @@ partial class CsvDataReader
 			{
 				this.state = State.End;
 			}
-		} 
-		else if(this.state == State.Error)
+		}
+		else if (this.state == State.Error)
 		{
-			throw new InvalidOperationException();
+			ThrowErrorState();
 		}
 		this.rowNumber = -1;
 		return false;

--- a/source/Sylvan.Data.Csv/CsvDataReader.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader.cs
@@ -384,6 +384,14 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 		}
 	}
 
+	void ThrowRecordTooLarge(int ordinal = 0)
+	{
+		// we know there's at least one more, but it doesn't fit in the buffer
+		this.curFieldCount++; 
+		this.state = State.Error;
+		throw new CsvRecordTooLargeException(this.rowNumber, ordinal);
+	}
+
 #if INTRINSICS
 
 	Vector256<byte> delimiterMaskVector256;
@@ -677,6 +685,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 			this.buffer = newBuffer;
 			return true;
 		}
+
 		return false;
 	}
 


### PR DESCRIPTION
Reading after an exception is thrown will not advance the row number. Subsequent calls to Read will also throw, but a different exception type.

Potential fix for #262