### PR TITLE
Update DataExtensions.cs

### DIFF
--- a/source/Sylvan.Data/DataExtensions.cs
+++ b/source/Sylvan.Data/DataExtensions.cs
@@ -54,6 +54,30 @@ public static partial class DataExtensions
 	}
 
 	/// <summary>
+	/// Creates a DbDataReader by prepending additional columns to an existing DbDataReader.
+	/// </summary>
+	/// <param name="reader">The base data reader.</param>
+	/// <param name="columns">The extra columns to prepend.</param>
+	/// <returns>A DbDataReader with the new columns added at the beginning.</returns>
+	public static DbDataReader WithColumnsFirst(this DbDataReader reader, params IDataColumn[] columns)
+	{
+	   var cols = new IDataColumn[reader.FieldCount + columns.Length];
+	   
+	   // Copy the new columns at the start
+	   Array.Copy(columns, 0, cols, 0, columns.Length);
+	   
+	   var schema = reader.CanGetColumnSchema() ? reader.GetColumnSchema() : null;
+	   // Add existing columns after the new ones
+	   for (int i = 0; i < reader.FieldCount; i++)
+	   {
+	       var allowNull = schema?[i].AllowDBNull ?? true;
+	       cols[i + columns.Length] = new DataReaderColumn(reader, i, allowNull);
+	   }
+	   
+	   return new MappedDataReader(reader, cols);
+	}
+
+	/// <summary>
 	/// Binds the DbDataReader data to produce a sequence of T.
 	/// </summary>
 	/// <typeparam name="T">The type of record to bind to.</typeparam>


### PR DESCRIPTION
Add WithColumnsFirst extension method to prepend columns to DbDataReader

Adds a new extension method similar to WithColumns but allows adding columns at the start of the reader instead of appending them at the end. This provides more flexibility when custom columns need to appear first in the output.