### PR TITLE
Skip the SimdExperiment test when SSE2 is not supported

### DIFF
--- a/source/Sylvan.Data.Csv.Tests/SimdExperiment.cs
+++ b/source/Sylvan.Data.Csv.Tests/SimdExperiment.cs
@@ -9,7 +9,18 @@ namespace Sylvan.Data.Csv;
 
 public unsafe class SimdExperiment
 {
-	[Fact]
+	private sealed class SkipIfSse2UnsupportedFactAttribute : FactAttribute
+	{
+		public SkipIfSse2UnsupportedFactAttribute()
+		{
+			if (!Sse2.IsSupported)
+			{
+				Skip = "SSE2 is not supported";
+			}
+		}
+	}
+
+	[SkipIfSse2UnsupportedFact]
 	public void Test1()
 	{
 		var mask = VectorForChar('\n');


### PR DESCRIPTION
So that all tests pass even on platforms that lack SSE2 support (such as ARM machines).