### PR TITLE
Rewrite all conditional compilation based on the target framework

### DIFF
--- a/source/Sylvan.Data.Csv/CsvDataAccessor.cs
+++ b/source/Sylvan.Data.Csv/CsvDataAccessor.cs
@@ -39,7 +39,7 @@ sealed class DynamicAccessor : FieldAccessor<object>
 	public override object GetValue(CsvDataReader reader, int ordinal)
 	{
 		//TODO: culture
-#if SPAN
+#if !NETSTANDARD2_0
 		var str = reader.GetFieldSpan(ordinal);
 #else
 		var str = reader.GetString(ordinal);

--- a/source/Sylvan.Data.Csv/CsvDataEnumAccessor.cs
+++ b/source/Sylvan.Data.Csv/CsvDataEnumAccessor.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace Sylvan.Data.Csv;
 
-#if SPAN
+#if !NETSTANDARD2_0
 delegate bool TryParse<T>(ReadOnlySpan<char> str, bool ignoreCase, out T value);
 #else
 delegate bool TryParse<T>(string str, bool ignoreCase, out T value);
@@ -13,7 +13,7 @@ delegate bool TryParse<T>(string str, bool ignoreCase, out T value);
 static class EnumParse
 {
 
-#if SPAN
+#if !NETSTANDARD2_0
 	static readonly Type ParamType = typeof(ReadOnlySpan<char>);
 #else
 	static readonly Type ParamType = typeof(string);
@@ -69,7 +69,7 @@ sealed class EnumAccessor<T> : IFieldAccessor<T>
 		{
 			throw new NotSupportedException();
 		}
-#if SPAN
+#if !NETSTANDARD2_0
 		var span = reader.GetFieldSpan(ordinal);
 #else
 		var span = reader.GetString(ordinal);
@@ -92,7 +92,7 @@ sealed class EnumAccessor : IFieldAccessor
 
 	public object GetValueAsObject(CsvDataReader reader, int ordinal)
 	{
-#if ENUM_SPAN_PARSE
+#if NET6_0_OR_GREATER
 		var span = reader.GetFieldSpan(ordinal);
 #else
 		var span = reader.GetString(ordinal);

--- a/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
@@ -324,21 +324,4 @@ partial class CsvDataReader
 		}
 		throw new NotSupportedException($"Unknown ResultSetMode.");
 	}
-
-#if NETSTANDARD2_1
-
-	/// <inheritdoc/>
-	public override Task CloseAsync()
-	{
-		if (this.state != State.Closed)
-		{
-			if (ownsReader)
-				this.reader.Dispose();
-			this.state = State.Closed;
-		}
-		return Task.CompletedTask;
-	}
-
-#endif
-
 }

--- a/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Async.cs
@@ -149,7 +149,7 @@ partial class CsvDataReader
 		this.minSafe = minSafe > quote ? minSafe : quote;
 		this.minSafeQuote = minSafe > escape ? minSafe : escape;
 
-#if INTRINSICS
+#if NETCOREAPP3_0_OR_GREATER
 		InitIntrinsics();
 #endif
 
@@ -230,7 +230,7 @@ partial class CsvDataReader
 		int fieldIdx = 0;
 		while (true)
 		{
-#if INTRINSICS
+#if NETCOREAPP3_0_OR_GREATER
 
 			if (ReadRecordFast(ref fieldIdx))
 			{
@@ -281,7 +281,7 @@ partial class CsvDataReader
 		recordStart = 0;
 
 		var count = buffer.Length - bufferEnd;
-#if SPAN
+#if !NETSTANDARD2_0
 		var memory = new Memory<char>(buffer, bufferEnd, count);
 		var c = await reader.ReadAsync(memory, cancel).ConfigureAwait(false);
 #else

--- a/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader+Sync.cs
@@ -96,7 +96,7 @@ partial class CsvDataReader
 		this.minSafe = minSafe > quote ? minSafe : quote;
 		this.minSafeQuote = minSafe > escape ? minSafe : escape;
 
-#if INTRINSICS
+#if NETCOREAPP3_0_OR_GREATER
 		InitIntrinsics();
 #endif
 
@@ -179,7 +179,7 @@ partial class CsvDataReader
 		{
 
 
-#if INTRINSICS
+#if NETCOREAPP3_0_OR_GREATER
 
 			if (ReadRecordFast(ref fieldIdx))
 			{

--- a/source/Sylvan.Data.Csv/CsvDataReader.cs
+++ b/source/Sylvan.Data.Csv/CsvDataReader.cs
@@ -13,7 +13,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-#if INTRINSICS
+#if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -452,7 +452,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 		return success;
 	}
 
-#if INTRINSICS
+#if NETCOREAPP3_0_OR_GREATER
 
 	Vector256<byte> delimiterMaskVector256;
 	Vector256<byte> lineEndMaskVector256;
@@ -1149,7 +1149,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 		var col = this.columns[ordinal];
 		var trueString = col.TrueString ?? this.trueString;
 		var falseString = col.FalseString ?? this.falseString;
-#if SPAN
+#if !NETSTANDARD2_0
 		var span = this.GetFieldSpan(ordinal);
 		if (trueString != null && span.Equals(trueString.AsSpan(), StringComparison.OrdinalIgnoreCase))
 		{
@@ -1202,7 +1202,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override byte GetByte(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		return byte.Parse(this.GetFieldSpan(ordinal), provider: culture);
 #else
 		return byte.Parse(this.GetString(ordinal), culture);
@@ -1366,7 +1366,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 
 	static void FromBase64Chars(char[] chars, int charsOffset, int charsLen, byte[] bytes, int bytesOffset, out int bytesWritten)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		if (!Convert.TryFromBase64Chars(chars.AsSpan().Slice(charsOffset, charsLen), bytes.AsSpan(bytesOffset), out bytesWritten))
 		{
 			throw new FormatException();
@@ -1412,7 +1412,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	public TimeSpan GetTimeSpan(int ordinal)
 	{
 		var format = columns[ordinal].Format;
-#if SPAN
+#if !NETSTANDARD2_0
 		var span = this.GetFieldSpan(ordinal);
 		if (format != null && TimeSpan.TryParseExact(span, format, culture, TimeSpanStyles.None, out var value))
 		{
@@ -1436,7 +1436,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	{
 		var format = columns[ordinal].Format ?? this.dateTimeFormat;
 		DateTimeOffset value;
-#if SPAN
+#if !NETSTANDARD2_0
 		var span = this.GetFieldSpan(ordinal);
 
 		if (IsoDate.TryParse(span, out value))
@@ -1461,7 +1461,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	public override DateTime GetDateTime(int ordinal)
 	{
 		DateTime value;
-#if SPAN
+#if !NETSTANDARD2_0
 		var span = this.GetFieldSpan(ordinal);
 		if (IsoDate.TryParse(span, out value))
 			return value;
@@ -1487,7 +1487,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override decimal GetDecimal(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		var field = this.GetField(ordinal);
 		return
 			field.TryParseSingleCharInt()
@@ -1500,7 +1500,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override double GetDouble(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		var field = this.GetField(ordinal);
 		return
 			field.TryParseSingleCharInt()
@@ -1532,7 +1532,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override float GetFloat(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		var field = this.GetField(ordinal);
 		return
 			field.TryParseSingleCharInt()
@@ -1545,7 +1545,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override Guid GetGuid(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		return Guid.Parse(this.GetFieldSpan(ordinal));
 #else
 		return Guid.Parse(this.GetString(ordinal));
@@ -1555,7 +1555,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override short GetInt16(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		var field = this.GetField(ordinal);
 		return
 			field.TryParseSingleCharInt()
@@ -1568,7 +1568,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override int GetInt32(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		var field = this.GetField(ordinal);
 		return
 			field.TryParseSingleCharInt()
@@ -1581,7 +1581,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 	/// <inheritdoc/>
 	public override long GetInt64(int ordinal)
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		var field = this.GetField(ordinal);
 		return
 			field.TryParseSingleCharInt()
@@ -1694,7 +1694,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 			return null;
 		}
 
-#if SPAN
+#if !NETSTANDARD2_0
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal Span<char> ToSpan()
@@ -2134,7 +2134,7 @@ public sealed partial class CsvDataReader : DbDataReader, IDbColumnSchemaGenerat
 		}
 	}
 
-#if SPAN
+#if !NETSTANDARD2_0
 
 	/// <summary>
 	/// Gets a span containing the characters of a field.

--- a/source/Sylvan.Data.Csv/CsvDataWriter+Async.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter+Async.cs
@@ -105,7 +105,7 @@ partial class CsvDataWriter
 		}
 		else
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			await writer.WriteAsync(buffer.AsMemory(0, recordStart), cancel).ConfigureAwait(false);
 #else
 			await writer.WriteAsync(buffer, 0, recordStart).ConfigureAwait(false);
@@ -166,7 +166,7 @@ partial class CsvDataWriter
 		buffer[pos++] = delimiter;
 	}
 
-#if ASYNC_DISPOSE
+#if !NETSTANDARD2_0
 	ValueTask IAsyncDisposable.DisposeAsync()
 	{
 		GC.SuppressFinalize(this);

--- a/source/Sylvan.Data.Csv/CsvDataWriter+FieldWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter+FieldWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Globalization;
@@ -306,7 +306,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[4];
 			if (!value.TryFormat(str, out int len, default, culture))
@@ -343,7 +343,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[6];
 			if (!value.TryFormat(str, out int len, default, culture))
@@ -380,7 +380,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[12];
 			if (!value.TryFormat(str, out int len, default, culture))
@@ -417,7 +417,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[20];
 			if (!value.TryFormat(str, out int len, default, culture))
@@ -447,7 +447,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[14];
 			if (!value.TryFormat(str, out int len, default, culture))
@@ -477,7 +477,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[16];
 			if (!value.TryFormat(str, out int len, default, culture))
@@ -507,7 +507,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[32];
 			if (!value.TryFormat(str, out int len, default, culture))
@@ -537,7 +537,7 @@ partial class CsvDataWriter
 		{
 			var writer = context.writer;
 			var culture = writer.culture;
-#if SPAN
+#if !NETSTANDARD2_0
 
 			Span<char> str = stackalloc char[36];
 			if (!value.TryFormat(str, out int len, default))
@@ -569,7 +569,7 @@ partial class CsvDataWriter
 			var culture = writer.culture;
 			// dateTimeFormat can be null here on ns2.0 (net4.8)
 			var fmt = writer.dateTimeFormat ?? "O";
-#if SPAN
+#if !NETSTANDARD2_0
 			// this buffer might not be sufficiently large.
 			Span<char> str = stackalloc char[IsoDate.MaxDateLength];
 			if (value.TryFormat(str, out int len, fmt, culture))
@@ -607,7 +607,7 @@ partial class CsvDataWriter
 
 			// dateTimeFormat can be null here on ns2.0 (net4.8)
 			var fmt = writer.dateTimeOffsetFormat ?? "O";
-#if SPAN
+#if !NETSTANDARD2_0
 			// this buffer might not be sufficiently large.
 			Span<char> str = stackalloc char[IsoDate.MaxDateLength];
 			if (value.TryFormat(str, out int len, fmt, culture))
@@ -642,7 +642,7 @@ partial class CsvDataWriter
 			var writer = context.writer;
 			var culture = writer.culture;
 			var fmt = writer.timeSpanFormat ?? "c";
-#if SPAN
+#if !NETSTANDARD2_0
 			// this buffer might not be sufficiently large.
 			Span<char> str = stackalloc char[IsoDate.MaxDateLength];
 			if (value.TryFormat(str, out int len, fmt, culture))
@@ -665,7 +665,7 @@ partial class CsvDataWriter
 	}
 
 
-#if SPAN
+#if !NETSTANDARD2_0
 
 sealed class DateTimeIsoFieldWriter : FieldWriter<DateTime>
 	{

--- a/source/Sylvan.Data.Csv/CsvDataWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvDataWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Data.Common;
@@ -14,7 +14,7 @@ namespace Sylvan.Data.Csv;
 /// </summary>
 public sealed partial class CsvDataWriter
 	: IDisposable
-#if ASYNC_DISPOSE
+#if !NETSTANDARD2_0
 	, IAsyncDisposable
 #endif
 {
@@ -95,7 +95,7 @@ public sealed partial class CsvDataWriter
 		}
 		if (type == typeof(byte))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastNumeric
 				? ByteFastFieldWriter.Instance
 				: ByteFieldWriter.Instance;
@@ -106,7 +106,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(short))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastNumeric
 				? Int16FastFieldWriter.Instance
 				: Int16FieldWriter.Instance;
@@ -117,7 +117,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(int))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastNumeric
 				? Int32FastFieldWriter.Instance
 				: Int32FieldWriter.Instance;
@@ -128,7 +128,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(long))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastNumeric
 				? Int64FastFieldWriter.Instance
 				: Int64FieldWriter.Instance;
@@ -138,7 +138,7 @@ public sealed partial class CsvDataWriter
 		}
 		if (type == typeof(float))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastNumeric
 				? SingleFastFieldWriter.Instance
 				: SingleFieldWriter.Instance;
@@ -149,7 +149,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(double))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastNumeric
 				? DoubleFastFieldWriter.Instance
 				: DoubleFieldWriter.Instance;
@@ -159,7 +159,7 @@ public sealed partial class CsvDataWriter
 		}
 		if (type == typeof(decimal))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastNumeric
 				? DecimalFastFieldWriter.Instance
 				: DecimalFieldWriter.Instance;
@@ -175,7 +175,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(DateTime))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			if (IsFastDateTime)
 			{
 				return DateTimeIsoFastFieldWriter.Instance;
@@ -193,7 +193,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(DateTimeOffset))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			if (IsFastDateTimeOffset)
 			{
 				return DateTimeOffsetIsoFastFieldWriter.Instance;
@@ -211,7 +211,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(Guid))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastConfig
 				? GuidFastFieldWriter.Instance
 				: GuidFieldWriter.Instance;
@@ -241,7 +241,7 @@ public sealed partial class CsvDataWriter
 
 		if (type == typeof(TimeSpan))
 		{
-#if SPAN
+#if !NETSTANDARD2_0
 			return IsFastTimeSpan
 				? TimeSpanFastFieldWriter.Instance
 				: TimeSpanFieldWriter.Instance;
@@ -283,7 +283,7 @@ public sealed partial class CsvDataWriter
 
 #endif
 
-#if SPAN
+#if !NETSTANDARD2_0
 		if (type.IsEnum)
 		{
 			if (!EnumMap.TryGetValue(type, out FieldWriter? writer))
@@ -310,7 +310,7 @@ public sealed partial class CsvDataWriter
 		return this.ObjectWriter;
 	}
 
-#if SPAN
+#if !NETSTANDARD2_0
 
 	static readonly ConcurrentDictionary<Type, FieldWriter> EnumMap = new();
 

--- a/source/Sylvan.Data.Csv/CsvWriter.cs
+++ b/source/Sylvan.Data.Csv/CsvWriter.cs
@@ -22,7 +22,7 @@ partial class CsvDataWriter
 		internal static readonly CsvWriter Escaped = new EscapedCsvWriter();
 		internal static readonly CsvWriter Quoted = new QuotedCsvWriter();
 
-#if SPAN
+#if !NETSTANDARD2_0
 		public virtual int Write(WriterContext context, ReadOnlySpan<char> value, char[] buffer, int offset)
 #else
 		public virtual int Write(WriterContext context, string value, char[] buffer, int offset)
@@ -31,7 +31,7 @@ partial class CsvDataWriter
 			return WriteEscaped(context, value, buffer, offset);
 		}
 
-#if SPAN
+#if !NETSTANDARD2_0
 		public abstract int WriteEscaped(WriterContext context, ReadOnlySpan<char> value, char[] buffer, int offset);
 #else
 		public abstract int WriteEscaped(WriterContext context, string value, char[] buffer, int offset);
@@ -41,7 +41,7 @@ partial class CsvDataWriter
 
 	sealed class EscapedCsvWriter : CsvWriter
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		public override int WriteEscaped(WriterContext context, ReadOnlySpan<char> value, char[] buffer, int offset)
 #else
 		public override int WriteEscaped(WriterContext context, string value, char[] buffer, int offset)
@@ -93,7 +93,7 @@ partial class CsvDataWriter
 
 	sealed class QuotedCsvWriter : CsvWriter
 	{
-#if SPAN
+#if !NETSTANDARD2_0
 		public override int Write(WriterContext context, ReadOnlySpan<char> value, char[] buffer, int offset)
 #else
 		public override int Write(WriterContext context, string value, char[] buffer, int offset)
@@ -106,7 +106,7 @@ partial class CsvDataWriter
 			}
 			return r;
 		}
-#if SPAN
+#if !NETSTANDARD2_0
 		static int WriteValueOptimistic(WriterContext context, ReadOnlySpan<char> value, char[] buffer, int offset)
 #else
 		static int WriteValueOptimistic(WriterContext context, string value, char[] buffer, int offset)
@@ -142,7 +142,7 @@ partial class CsvDataWriter
 			return value.Length;
 		}
 
-#if SPAN
+#if !NETSTANDARD2_0
 		public override int WriteEscaped(WriterContext context, ReadOnlySpan<char> value, char[] buffer, int offset)
 #else
 		public override int WriteEscaped(WriterContext context, string value, char[] buffer, int offset)

--- a/source/Sylvan.Data.Csv/Sylvan.Data.Csv.csproj
+++ b/source/Sylvan.Data.Csv/Sylvan.Data.Csv.csproj
@@ -7,10 +7,8 @@
 		<PackageTags>csv;delimited;data;datareader;datawriter;simd</PackageTags>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<DefineConstants Condition="$(TargetFramework) == 'netstandard2.1'">SPAN;ASYNC_DISPOSE;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="$(TargetFramework) == 'net6.0'">SPAN;ASYNC_DISPOSE;INTRINSICS;ENUM_SPAN_PARSE;$(DefineConstants)</DefineConstants>
 		<!-- Enable unsafe blocks for use with simd -->
-		<AllowUnsafeBlocks Condition="$(TargetFramework) == 'net6.0'">true</AllowUnsafeBlocks>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/Sylvan.Data/DataExtensions.cs
+++ b/source/Sylvan.Data/DataExtensions.cs
@@ -94,7 +94,7 @@ public static partial class DataExtensions
 		return new TakeWhileDataReader(reader, predicate);
 	}
 
-#if IAsyncEnumerable
+#if !NETSTANDARD2_0
 
 	/// <summary>
 	/// Binds the DbDataReader data to produce a sequence of T.

--- a/source/Sylvan.Data/ObjectDataReader.cs
+++ b/source/Sylvan.Data/ObjectDataReader.cs
@@ -26,7 +26,7 @@ public static class ObjectDataReader
 		return new SyncObjectDataReader<T>(data);
 	}
 
-#if IAsyncEnumerable
+#if !NETSTANDARD2_0
 
 	/// <summary>
 	/// Creates a DbDataReader over a sequence of objects.
@@ -108,7 +108,7 @@ public static class ObjectDataReader
 			return builder.Build(data);
 		}
 
-#if IAsyncEnumerable
+#if !NETSTANDARD2_0
 
 		/// <summary>
 		/// Builds a DbDataReader over the data that will read the columns defined by the builder.
@@ -151,7 +151,7 @@ sealed class SyncObjectDataReader<T> : ObjectDataReader<T>
 	public override T Current => this.enumerator.Current;
 }
 
-#if IAsyncEnumerable
+#if !NETSTANDARD2_0
 
 sealed class AsyncObjectDataReader<T> : ObjectDataReader<T>
 {
@@ -332,7 +332,7 @@ abstract class ObjectDataReader<T> : DbDataReader, IDbColumnSchemaGenerator
 			return new SyncObjectDataReader<T>(data, this.columns.ToArray());
 		}
 
-#if IAsyncEnumerable
+#if !NETSTANDARD2_0
 
 		internal DbDataReader Build(IAsyncEnumerable<T> data, CancellationToken cancel)
 		{

--- a/source/Sylvan.Data/Sylvan.Data.csproj
+++ b/source/Sylvan.Data/Sylvan.Data.csproj
@@ -7,7 +7,6 @@
 		<PackageTags>data;datareader;ADO.NET</PackageTags>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<DefineConstants Condition="$(TargetFramework) != 'netstandard2.0'">$(DefineConstants);IAsyncEnumerable</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This is future proof. Adding a new target framework will just work, without needing to tweak the `DefineConstants` property and risking to miss something.

Also, the `CsvDataReader.CloseAsync` implementation (.NET Standard 2.1 only) was removed. Since it's not actually asynchronous, it's exactly equivalent as what the base class does, i.e., calling Close() and returning Task.CompletedTask.